### PR TITLE
fix:justified elements and added a mb-5 in mobile mode

### DIFF
--- a/src/components/Footer/index.astro
+++ b/src/components/Footer/index.astro
@@ -6,11 +6,11 @@ import github from "../../assets/github-white.svg";
   class="lg:flex sm:flex-col lg:flex-row p-5 m-5 justify-around items-center"
 >
   <div>
-    <p class="md:text-2xl sm:text-lg text-white text-center">
+    <p class="md:text-2xl sm:text-lg text-white text-center mb-5 lg:mb-0">
       Tech Conf - {new Date().getFullYear()}
     </p>
   </div>
-  <div class="flex items-center gap-5">
+  <div class="flex items-center gap-5 justify-center">
     <a
       class="bg-gray-900 text-white py-3 px-5 rounded-full shadow-md text-lg"
       href="https://mail.google.com/mail/?view=cm&fs=1&tf=1&to=linderhassinger00@gmail.com&body=Quiero%20contactarme%20con%20el%20equipo%20de%20Tech%20Conf"


### PR DESCRIPTION
Footer: Elementos centrados, y padding añadido

## Description
Se centraron los botones Contactanos y Github Signin y se añadió un padding  botton de 5 en modo móvil.


## Screenshots (if appropriate):
Antes: 
![image](https://user-images.githubusercontent.com/125331996/222311244-12176aab-cda6-409e-b2a1-5eff2a9f992f.png)

Después:
![image](https://user-images.githubusercontent.com/125331996/222311100-e890bc93-459c-4931-b60c-14006b1360b6.png)


