### PR TITLE
Fixed github logo import path on tickets page

### DIFF
--- a/src/components/Tickets/index.tsx
+++ b/src/components/Tickets/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { getUser, signInWithGitHub } from "../../services/auth";
 import { getDataFromTable } from "../../services/config";
-import github from "../../assets/github-white.svg";
+import github from "../../assets/github-mark.svg";
 import type { User } from "../../interfaces/user";
 import type { ITickets } from "../../interfaces/tickets";
 import "./index.css";


### PR DESCRIPTION
## Description
I changed the import path for Github Logo on `Tickets` page. Originally this was white logo that was blending with background and nothing see anything. Now the logo is black version.


## Related Issue
`This ->` #9 

## Motivation and Context
Because the Github logo doesn't see on `Tickets` page.

## How Has This Been Tested?
Manually, on local dev server and navigator development tools.

## Screenshots:
![imagen](https://user-images.githubusercontent.com/86406248/222654521-7ae4eb4f-800d-42b7-9598-854c7d819aeb.png)


